### PR TITLE
Stabilize HayaSelect open by focusing target

### DIFF
--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -320,8 +320,7 @@ private
 
   def wait_for_open
     wait_for_browser do
-      scope.page.has_selector?(opened_current_selected_selector) ||
-        scope.page.has_selector?(options_selector)
+      scope.page.has_selector?(options_selector, visible: true)
     end
   end
 

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -85,8 +85,6 @@ class HayaSelect
     attempts = 0
 
     begin
-      return self if selected?(label, value)
-
       open
       selected_value = select_option_value(label:, value:)
       wait_for_selected_value_or_label(label, value || selected_value)

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -85,6 +85,8 @@ class HayaSelect
     attempts = 0
 
     begin
+      return self if selected?(label, value)
+
       open
       selected_value = select_option(label:, value:)
       wait_for_selected_value_or_label(label, value || selected_value)
@@ -222,6 +224,17 @@ private
 
       expect(label_matches || value_matches).to eq true
     end
+  end
+
+  def selected?(label, value)
+    return false unless label || value
+
+    label_matches = label && scope.page.has_selector?(current_option_selector(label))
+    value_matches = value && scope.page.has_selector?(current_value_selector(value))
+
+    label_matches || value_matches
+  rescue Selenium::WebDriver::Error::StaleElementReferenceError
+    retry
   end
 
   def search_for_option(label)

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -178,10 +178,13 @@ class HayaSelect
 private
 
   def select_option_selector(label:, value:)
-    selector = "#{options_selector} [data-testid='option-presentation']"
-    selector << "[data-text='#{label}']" unless label.nil?
-    selector << "[data-value='#{value}']" unless value.nil?
-    selector
+    if value
+      "#{select_option_container_selector}[data-value='#{value}']"
+    else
+      selector = "#{options_selector} [data-testid='option-presentation']"
+      selector << "[data-text='#{label}']" unless label.nil?
+      selector
+    end
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -385,12 +388,20 @@ private
   def find_option_element(selector, label)
     return wait_for_and_find(selector) unless label
 
+    if selector.start_with?(select_option_container_selector)
+      return wait_for_and_find(selector)
+    end
+
     return wait_for_and_find(selector) if scope.page.has_selector?(selector)
 
     option_text = wait_for_and_find(option_label_selector, text: label)
-    option_text.find(:xpath, "./ancestor::*[@data-testid='option-presentation']")
+    option_text.find(:xpath, "./ancestor::*[@data-class='select-option']")
   rescue Selenium::WebDriver::Error::StaleElementReferenceError
     retry
+  end
+
+  def select_option_container_selector
+    "#{options_selector} [data-class='select-option']"
   end
 
   # rubocop:enable Metrics/ClassLength, Style/Documentation

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -287,6 +287,7 @@ private
       end
 
     element = wait_for_and_find(target_selector)
+    scope.page.execute_script("arguments[0].focus()", element)
     scope.page.execute_script(
       "arguments[0].scrollIntoView({block: 'center', inline: 'center'})",
       element
@@ -295,21 +296,7 @@ private
 
     return if scope.page.has_selector?(opened_current_selected_selector)
 
-    scope.page.execute_script(
-      <<~JS,
-        const target = arguments[0]
-        const events = [
-          new PointerEvent('pointerdown', {bubbles: true, cancelable: true}),
-          new MouseEvent('mousedown', {bubbles: true, cancelable: true}),
-          new PointerEvent('pointerup', {bubbles: true, cancelable: true}),
-          new MouseEvent('mouseup', {bubbles: true, cancelable: true}),
-          new MouseEvent('click', {bubbles: true, cancelable: true})
-        ]
-
-        for (const event of events) target.dispatchEvent(event)
-      JS
-      element
-    )
+    dispatch_open_events(element)
   end
 
   def current_selected_selector
@@ -328,6 +315,24 @@ private
     select_container = wait_for_and_find(select_container_selector)
     select_container.send_keys(:enter)
     select_container.send_keys(:space)
+  end
+
+  def dispatch_open_events(element)
+    scope.page.execute_script(
+      <<~JS,
+        const target = arguments[0]
+        const events = [
+          new PointerEvent('pointerdown', {bubbles: true, cancelable: true}),
+          new MouseEvent('mousedown', {bubbles: true, cancelable: true}),
+          new PointerEvent('pointerup', {bubbles: true, cancelable: true}),
+          new MouseEvent('mouseup', {bubbles: true, cancelable: true}),
+          new MouseEvent('click', {bubbles: true, cancelable: true})
+        ]
+
+        for (const event of events) target.dispatchEvent(event)
+      JS
+      element
+    )
   end
 
   def current_option_selector(label)

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -87,6 +87,7 @@ class HayaSelect
     begin
       open
       selected_value = select_option_value(label:, value:)
+      selected_value = "" if selected_value.nil? && value.nil?
       wait_for_selected_value_or_label(label, value || selected_value)
       close_if_open
       self

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -314,7 +314,8 @@ private
 
   def wait_for_open
     wait_for_browser do
-      scope.page.has_selector?(opened_current_selected_selector) && scope.page.has_selector?(options_selector)
+      scope.page.has_selector?(opened_current_selected_selector) ||
+        scope.page.has_selector?(options_selector)
     end
   end
 

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -376,7 +376,7 @@ private
 
   def option_present?(selector, label)
     scope.page.has_selector?(selector) ||
-      scope.page.has_selector?(option_label_selector, exact_text: label)
+      scope.page.has_selector?(option_label_selector, text: label)
   end
 
   def find_option_element(selector, label)
@@ -384,7 +384,7 @@ private
 
     return wait_for_and_find(selector) if scope.page.has_selector?(selector)
 
-    option_text = wait_for_and_find(option_label_selector, exact_text: label)
+    option_text = wait_for_and_find(option_label_selector, text: label)
     option_text.find(:xpath, "./ancestor::*[@data-testid='option-presentation']")
   rescue Selenium::WebDriver::Error::StaleElementReferenceError
     retry

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -395,9 +395,7 @@ private
   def find_option_element(selector, label)
     return wait_for_and_find(selector, visible: :all) unless label
 
-    if selector.start_with?(select_option_container_selector)
-      return wait_for_and_find(selector, visible: :all)
-    end
+    return wait_for_and_find(selector, visible: :all) if selector.start_with?(select_option_container_selector)
 
     return wait_for_and_find(selector, visible: :all) if scope.page.has_selector?(selector, visible: :all)
 

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -123,7 +123,7 @@ class HayaSelect
 
   def wait_for_label(expected_label)
     wait_for_selector(
-      "#{base_selector} [data-class='current-selected'] [data-class='current-option']",
+      current_option_label_selector,
       exact_text: expected_label
     )
     self
@@ -219,7 +219,7 @@ private
 
   def wait_for_selected_value_or_label(label, value)
     wait_for_expect do
-      label_matches = label && scope.page.has_selector?(current_option_selector(label))
+      label_matches = label && scope.page.has_selector?(current_option_label_selector, exact_text: label)
       value_matches = value && scope.page.has_selector?(current_value_selector(value))
 
       expect(label_matches || value_matches).to eq true
@@ -229,7 +229,7 @@ private
   def selected?(label, value)
     return false unless label || value
 
-    label_matches = label && scope.page.has_selector?(current_option_selector(label))
+    label_matches = label && scope.page.has_selector?(current_option_label_selector, exact_text: label)
     value_matches = value && scope.page.has_selector?(current_value_selector(value))
 
     label_matches || value_matches
@@ -348,8 +348,8 @@ private
     )
   end
 
-  def current_option_selector(label)
-    "#{base_selector} [data-class='current-selected'] [data-class='current-option'][data-text='#{label}']"
+  def current_option_label_selector
+    "#{base_selector} [data-class='current-selected'] [data-testid='option-presentation-text']"
   end
 
   def current_value_selector(value)


### PR DESCRIPTION
## Problem
HayaSelect sometimes fails to open on CI, leaving the options container empty and causing select helpers to time out.

## Fix
Focus the select target before scrolling/clicking, and move the fallback event dispatch to a helper method to keep the open path consistent.

## Testing
- bundle exec rubocop