### PR TITLE
Prefer clicking option presentation

### DIFF
--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -466,6 +466,26 @@ private
       visible: false
     )
     input.set(option_value)
+    return if input.value == option_value
+
+    scope.page.execute_script(
+      <<~JS,
+        const input = arguments[0]
+        const value = arguments[1]
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set
+
+        if (setter) {
+          setter.call(input, value)
+        } else {
+          input.value = value
+        }
+
+        input.setAttribute("value", value)
+        input.dispatchEvent(new Event("input", {bubbles: true}))
+        input.dispatchEvent(new Event("change", {bubbles: true}))
+      JS
+      input, option_value
+    )
   end
 
   def current_option_label_selectors

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -455,17 +455,11 @@ private
   end
 
   def force_set_hidden_value(option_value)
-    scope.page.execute_script(
-      <<~JS
-        const base = document.querySelector("#{base_selector}")
-        if (!base) return
-        const input = base.querySelector("[data-class='current-selected'] input[type='hidden']")
-        if (!input) return
-        input.value = "#{option_value}"
-        input.dispatchEvent(new Event("input", {bubbles: true}))
-        input.dispatchEvent(new Event("change", {bubbles: true}))
-      JS
+    input = scope.page.find(
+      "#{base_selector} [data-class='current-selected'] input[type='hidden']",
+      visible: false
     )
+    input.set(option_value)
   end
 
   def current_option_label_selectors
@@ -521,7 +515,7 @@ private
   end
 
   def option_click_target(option)
-    option
+    option.find("[data-testid='option-presentation']", minimum: 0) || option
   end
 
   def click_target_element(click_target)
@@ -532,7 +526,7 @@ private
       )
     end
 
-    scope.page.driver.browser.action.move_to(click_target.native).click.perform
+    click_element_safely(click_target)
   end
 
   def select_option_container_selector

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -115,12 +115,16 @@ class HayaSelect
     selector = select_option_selector(label: label, value: value)
     wait_for_option(selector, label)
     option = find_option_element(selector, label)
-    click_target = option_click_target(option)
 
     raise "The '#{label}'-option is disabled" if option['data-disabled'] == 'true'
 
     option_value = option['data-value']
-    click_target_element(click_target)
+    click_element_safely(option)
+
+    unless selected?(label, option_value)
+      option_presentation = option.all("[data-testid='option-presentation']", minimum: 0).first
+      click_element_safely(option_presentation) if option_presentation
+    end
 
     unless selected?(label, option_value)
       option.send_keys(:enter)
@@ -512,10 +516,6 @@ private
     option_text.find(:xpath, "./ancestor::*[@data-class='select-option']")
   rescue Selenium::WebDriver::Error::StaleElementReferenceError
     retry
-  end
-
-  def option_click_target(option)
-    option.find("[data-testid='option-presentation']", minimum: 0) || option
   end
 
   def click_target_element(click_target)

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -444,12 +444,14 @@ private
     scope.page.execute_script(
       <<~JS,
         const target = arguments[0]
+        const pointerBase = {bubbles: true, cancelable: true, pointerType: 'mouse', isPrimary: true, button: 0, buttons: 1}
+        const mouseBase = {bubbles: true, cancelable: true, button: 0, buttons: 1}
         const events = [
-          new PointerEvent('pointerdown', {bubbles: true, cancelable: true}),
-          new MouseEvent('mousedown', {bubbles: true, cancelable: true}),
-          new PointerEvent('pointerup', {bubbles: true, cancelable: true}),
-          new MouseEvent('mouseup', {bubbles: true, cancelable: true}),
-          new MouseEvent('click', {bubbles: true, cancelable: true})
+          new PointerEvent('pointerdown', pointerBase),
+          new MouseEvent('mousedown', mouseBase),
+          new PointerEvent('pointerup', pointerBase),
+          new MouseEvent('mouseup', mouseBase),
+          new MouseEvent('click', mouseBase)
         ]
 
         for (const event of events) target.dispatchEvent(event)

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -119,11 +119,11 @@ class HayaSelect
     raise "The '#{label}'-option is disabled" if option['data-disabled'] == 'true'
 
     option_value = option['data-value']
-    click_element_safely(option)
+    click_option_element(option)
 
     unless selected?(label, option_value)
       option_presentation = option.all("[data-testid='option-presentation']", minimum: 0).first
-      click_element_safely(option_presentation) if option_presentation
+      click_option_element(option_presentation) if option_presentation
     end
 
     unless selected?(label, option_value)
@@ -527,6 +527,19 @@ private
     end
 
     click_element_safely(click_target)
+  end
+
+  def click_option_element(element)
+    return if element.nil?
+
+    unless element.visible?
+      scope.page.execute_script(
+        "arguments[0].scrollIntoView({block: 'center', inline: 'center'})",
+        element
+      )
+    end
+
+    scope.page.driver.browser.action.move_to(element.native).click.perform
   end
 
   def select_option_container_selector

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -119,20 +119,7 @@ class HayaSelect
     raise "The '#{label}'-option is disabled" if option['data-disabled'] == 'true'
 
     option_value = option['data-value']
-    click_option_element(option)
-
-    unless selected?(label, option_value)
-      option_presentation = option.all("[data-testid='option-presentation']", minimum: 0).first
-      click_option_element(option_presentation) if option_presentation
-    end
-
-    unless selected?(label, option_value)
-      option.send_keys(:enter)
-      option.send_keys(:space)
-    end
-
-    dispatch_option_events(option) unless selected?(label, option_value)
-    force_set_hidden_value(option_value) unless selected?(label, option_value)
+    perform_option_selection(option, label, option_value)
 
     option_value
   rescue Selenium::WebDriver::Error::StaleElementReferenceError
@@ -558,6 +545,29 @@ private
     element.native.click
   rescue Selenium::WebDriver::Error::ElementClickInterceptedError
     scope.page.driver.browser.action.move_to(element.native).click.perform
+  end
+
+  def perform_option_selection(option, label, option_value)
+    click_option_element(option)
+    click_option_presentation(option, label, option_value)
+    send_option_keys(option, label, option_value)
+    dispatch_option_events(option) unless selected?(label, option_value)
+    force_set_hidden_value(option_value) unless selected?(label, option_value)
+  end
+
+  def click_option_presentation(option, label, option_value)
+    return if selected?(label, option_value)
+
+    option_presentation = option.all("[data-testid='option-presentation']", minimum: 0).first
+    click_option_element(option_presentation) if option_presentation
+  end
+
+  def send_option_keys(option, label, option_value)
+    return if selected?(label, option_value)
+
+    scope.page.execute_script("arguments[0].focus()", option)
+    option.send_keys(:enter)
+    option.send_keys(:space)
   end
 
   def select_option_container_selector

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -534,13 +534,9 @@ private
   def click_option_element(element)
     return if element.nil?
 
-    unless element.visible?
-      scope.page.execute_script(
-        "arguments[0].scrollIntoView({block: 'center', inline: 'center'})",
-        element
-      )
-    end
-
+    element.native.location_once_scrolled_into_view
+    element.native.click
+  rescue Selenium::WebDriver::Error::ElementClickInterceptedError
     scope.page.driver.browser.action.move_to(element.native).click.perform
   end
 


### PR DESCRIPTION
## Problem
Option selections were flaky because the helper clicked the container element, which can miss the active press handler.

## Fix
Click the option presentation element when present and fall back to the container.

## Testing
- bundle exec rubocop lib/haya_select.rb