### PR TITLE
Ignore non-interactable scroll errors

### DIFF
--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -468,7 +468,12 @@ private
   def click_option_element(element)
     raise ArgumentError, "Expected a clickable option element, got nil" if element.nil?
 
-    element.native.location_once_scrolled_into_view
+    begin
+      element.native.location_once_scrolled_into_view
+    rescue Selenium::WebDriver::Error::ElementNotInteractableError
+      nil
+    end
+
     element.click
   end
 

--- a/spec/haya_select_spec.rb
+++ b/spec/haya_select_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe HayaSelect do
+  describe "#click_option_element" do
+    it "ignores ElementNotInteractableError from location_once_scrolled_into_view" do
+      scope = instance_double(Capybara::Session)
+      native = instance_double(Selenium::WebDriver::Element)
+      element = instance_double(Capybara::Node::Element, native: native)
+
+      allow(native).to receive(:location_once_scrolled_into_view)
+        .and_raise(Selenium::WebDriver::Error::ElementNotInteractableError)
+      expect(element).to receive(:click)
+
+      expect do
+        described_class.new(id: "example", scope: scope).send(:click_option_element, element)
+      end.not_to raise_error
+    end
+  end
+end

--- a/spec/haya_select_spec.rb
+++ b/spec/haya_select_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe HayaSelect do
       native = instance_double(Selenium::WebDriver::Element)
       element = instance_double(Capybara::Node::Element, native: native)
 
-      allow(native).to receive(:location_once_scrolled_into_view)
+      expect(native).to receive(:location_once_scrolled_into_view)
         .and_raise(Selenium::WebDriver::Error::ElementNotInteractableError)
       expect(element).to receive(:click)
 


### PR DESCRIPTION
## Problem
System specs can fail when `location_once_scrolled_into_view` raises `ElementNotInteractableError` for portal-rendered options, even though the option is clickable.

## Fix
Rescue `ElementNotInteractableError` only around the scroll-into-view call and proceed with the click. Added a unit spec to guard the behavior.

## Testing
- bundle exec rspec spec/haya_select_spec.rb