### PR TITLE
Wait for selected state after option click

### DIFF
--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -500,8 +500,7 @@ private
 
   def perform_option_selection(option, label, option_value)
     click_option_element(option)
-
-    raise "Expected option to be selected after clicking it" unless selected?(label, option_value)
+    wait_for_selected_value_or_label(label, option_value)
   end
 
   def select_option_container_selector


### PR DESCRIPTION
Problem:
- Option selection sometimes updates async, so immediate selected? checks can fail and raise.

Fix:
- Wait for selected label/value after clicking an option instead of raising immediately.

Testing:
- bundle exec rspec spec/haya_select_spec.rb