### PR TITLE
Fail fast when selecting already selected option

### DIFF
--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -89,17 +89,21 @@ class HayaSelect
     retry
   end
 
-  def select(label = nil, value: nil)
+  def select(label = nil, value: nil, allow_if_selected: false)
     attempts = 0
 
     begin
       current_value = value_no_wait
 
       if !value.nil? && current_value == value
+        return self if allow_if_selected
+
         raise "The '#{label || value}'-option is already selected"
       end
 
       if value.nil? && !label.nil? && label_no_wait == label
+        return self if allow_if_selected
+
         raise "The '#{label}'-option is already selected"
       end
 

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -93,21 +93,7 @@ class HayaSelect
     attempts = 0
 
     begin
-      if attempts == 0
-        current_value = value_no_wait
-
-        if !value.nil? && current_value == value
-          return self if allow_if_selected
-
-          raise "The '#{label || value}'-option is already selected"
-        end
-
-        if value.nil? && !label.nil? && label_no_wait == label
-          return self if allow_if_selected
-
-          raise "The '#{label}'-option is already selected"
-        end
-      end
+      guard_already_selected(label, value, allow_if_selected) if attempts.zero?
 
       previous_value = value
       open
@@ -121,6 +107,22 @@ class HayaSelect
       attempts += 1
       retry if attempts < 3
       raise
+    end
+  end
+
+  def guard_already_selected(label, value, allow_if_selected)
+    current_value = value_no_wait
+
+    if !value.nil? && current_value == value
+      return if allow_if_selected
+
+      raise "The '#{label || value}'-option is already selected"
+    end
+
+    if value.nil? && !label.nil? && label_no_wait == label
+      return if allow_if_selected
+
+      raise "The '#{label}'-option is already selected"
     end
   end
 

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -93,6 +93,16 @@ class HayaSelect
     attempts = 0
 
     begin
+      current_value = value_no_wait
+
+      if !value.nil? && current_value == value
+        raise "The '#{label || value}'-option is already selected"
+      end
+
+      if value.nil? && !label.nil? && label_no_wait == label
+        raise "The '#{label}'-option is already selected"
+      end
+
       previous_value = value
       open
       selected_value = select_option_value(label:, value:)
@@ -106,6 +116,28 @@ class HayaSelect
       retry if attempts < 3
       raise
     end
+  end
+
+  def value_no_wait
+    hidden_input = scope.page.first(
+      "#{base_selector} [data-class='current-selected'] input[type='hidden']",
+      visible: false,
+      wait: 0
+    )
+
+    hidden_input ? hidden_input[:value] : nil
+  end
+
+  def label_no_wait
+    current_option = scope.page.first(
+      "#{base_selector} [data-class='current-selected'] [data-class='current-option']",
+      wait: 0
+    )
+
+    return nil unless current_option
+
+    option_text = current_option.first("[data-testid='option-presentation-text']", minimum: 0)
+    option_text ? option_text.text : current_option.text
   end
 
   def deselect(label: nil, value: nil)

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -93,18 +93,20 @@ class HayaSelect
     attempts = 0
 
     begin
-      current_value = value_no_wait
+      if attempts == 0
+        current_value = value_no_wait
 
-      if !value.nil? && current_value == value
-        return self if allow_if_selected
+        if !value.nil? && current_value == value
+          return self if allow_if_selected
 
-        raise "The '#{label || value}'-option is already selected"
-      end
+          raise "The '#{label || value}'-option is already selected"
+        end
 
-      if value.nil? && !label.nil? && label_no_wait == label
-        return self if allow_if_selected
+        if value.nil? && !label.nil? && label_no_wait == label
+          return self if allow_if_selected
 
-        raise "The '#{label}'-option is already selected"
+          raise "The '#{label}'-option is already selected"
+        end
       end
 
       previous_value = value


### PR DESCRIPTION
Problem:
- The HayaSelect helper can re-select a value that is already selected, masking cases where selections aren't changing.

Solution:
- Add a no-wait guard that raises when the current selection already matches the requested label/value.

Testing:
- Not run (not requested).