### PR TITLE
Use Rails.logger.debug for HayaSelect debug output

### DIFF
--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -318,10 +318,11 @@ private
     value_input_selector = "#{base_selector} [data-class='current-selected'] input[type='hidden']"
     has_value_input_initial = scope.page.has_selector?(value_input_selector, visible: false, wait: 0)
     current_value_initial = scope.page.first(value_input_selector, visible: false, wait: 0)&.[](:value)
-    current_option = scope.page.all(
+    current_option = scope.page.first(
       "#{base_selector} [data-class='current-selected'] [data-class='current-option']",
+      minimum: 0,
       wait: 0
-    ).first
+    )
     current_label_initial =
       if current_option
         option_text = current_option.first("[data-testid='option-presentation-text']", minimum: 0)

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -93,34 +93,14 @@ class HayaSelect
     attempts = 0
 
     begin
-      Rails.logger.debug do
-        "[haya_select] select start selector=#{base_selector} " \
-          "label=#{label.inspect} value=#{value.inspect} " \
-          "allow_if_selected=#{allow_if_selected} attempts=#{attempts}"
-      end
+      log_select_start(label, value, allow_if_selected, attempts)
       guard_already_selected(label, value, allow_if_selected) if attempts.zero?
 
-      previous_value = value
-      Rails.logger.debug { "[haya_select] open selector=#{base_selector}" }
-      open
-      Rails.logger.debug { "[haya_select] select_option_value selector=#{base_selector}" }
-      selected_value = select_option_value(label:, value:)
-      Rails.logger.debug do
-        "[haya_select] select_option_value selector=#{base_selector} selected_value=#{selected_value.inspect}"
-      end
-      selected_value = "" if selected_value.nil? && value.nil?
-      allow_blank = previous_value == selected_value
-      Rails.logger.debug { "[haya_select] close_if_open selector=#{base_selector}" }
-      close_if_open
-      Rails.logger.debug do
-        "[haya_select] wait_for_selected_value_or_label " \
-          "selector=#{base_selector} label=#{label.inspect} " \
-          "value=#{(value || selected_value).inspect} allow_blank=#{allow_blank}"
-      end
-      wait_for_selected_value_or_label(label, value || selected_value, allow_blank:)
+      selected_value, allow_blank = select_value_and_close(label:, value:)
+      wait_for_selected_after_select(label, value, selected_value, allow_blank)
       self
     rescue WaitUtil::TimeoutError, Selenium::WebDriver::Error::StaleElementReferenceError
-      Rails.logger.debug { "[haya_select] select retry selector=#{base_selector} attempts=#{attempts}" }
+      log_select_retry(attempts)
       attempts += 1
       retry if attempts < 3
       raise
@@ -312,42 +292,18 @@ private
   end
 
   def wait_for_selected_value_or_label(label, value, allow_blank: false)
-    Rails.logger.debug do
-      "[haya_select] wait_for_selected_value_or_label start selector=#{base_selector} label=#{label.inspect} value=#{value.inspect} allow_blank=#{allow_blank}"
-    end
+    log_wait_for_selected_start(label, value, allow_blank)
     value_input_selector = "#{base_selector} [data-class='current-selected'] input[type='hidden']"
-    has_value_input_initial = scope.page.has_selector?(value_input_selector, visible: false, wait: 0)
-    current_value_initial = scope.page.first(value_input_selector, visible: false, wait: 0)&.[](:value)
-    current_option = scope.page.first(
-      "#{base_selector} [data-class='current-selected'] [data-class='current-option']",
-      minimum: 0,
-      wait: 0
-    )
-    current_label_initial =
-      if current_option
-        option_text = current_option.first("[data-testid='option-presentation-text']", minimum: 0)
-        option_text ? option_text.text : current_option.text
-      end
-    Rails.logger.debug do
-      "[haya_select] wait_for_selected_value_or_label initial " \
-        "selector=#{base_selector} has_value_input=#{has_value_input_initial} " \
-        "current_value=#{current_value_initial.inspect} " \
-        "current_label=#{current_label_initial.inspect}"
-    end
+    log_wait_for_selected_initial_state(value_input_selector)
     wait_for_expect do
-      has_value_input = scope.page.has_selector?(value_input_selector, visible: false)
-      label_matches = label && label_matches?(label)
-      value_matches = value && scope.page.has_selector?(current_value_selector(value), visible: false)
-      blank_matches = allow_blank && scope.page.has_selector?(current_value_selector(""), visible: false)
-
-      matches =
-        if has_value_input
-          value_matches || blank_matches
-        else
-          label_matches || value_matches || blank_matches
-        end
-
-      expect(matches).to eq true
+      expect(
+        selected_value_or_label_matches?(
+          label:,
+          value:,
+          allow_blank:,
+          value_input_selector:
+        )
+      ).to eq true
     end
   end
 
@@ -597,6 +553,83 @@ private
 
   def select_option_container_selector
     "#{options_selector} [data-class='select-option']"
+  end
+
+  def log_select_start(label, value, allow_if_selected, attempts)
+    Rails.logger.debug do
+      "[haya_select] select start selector=#{base_selector} " \
+        "label=#{label.inspect} value=#{value.inspect} " \
+        "allow_if_selected=#{allow_if_selected} attempts=#{attempts}"
+    end
+  end
+
+  def select_value_and_close(label:, value:)
+    previous_value = value
+    Rails.logger.debug { "[haya_select] open selector=#{base_selector}" }
+    open
+    Rails.logger.debug { "[haya_select] select_option_value selector=#{base_selector}" }
+    selected_value = select_option_value(label:, value:)
+    Rails.logger.debug do
+      "[haya_select] select_option_value selector=#{base_selector} selected_value=#{selected_value.inspect}"
+    end
+    selected_value = "" if selected_value.nil? && value.nil?
+    allow_blank = previous_value == selected_value
+    Rails.logger.debug { "[haya_select] close_if_open selector=#{base_selector}" }
+    close_if_open
+    [selected_value, allow_blank]
+  end
+
+  def wait_for_selected_after_select(label, value, selected_value, allow_blank)
+    expected_value = value || selected_value
+    Rails.logger.debug do
+      "[haya_select] wait_for_selected_value_or_label " \
+        "selector=#{base_selector} label=#{label.inspect} " \
+        "value=#{expected_value.inspect} allow_blank=#{allow_blank}"
+    end
+    wait_for_selected_value_or_label(label, expected_value, allow_blank:)
+  end
+
+  def log_select_retry(attempts)
+    Rails.logger.debug { "[haya_select] select retry selector=#{base_selector} attempts=#{attempts}" }
+  end
+
+  def log_wait_for_selected_start(label, value, allow_blank)
+    Rails.logger.debug do
+      "[haya_select] wait_for_selected_value_or_label start selector=#{base_selector} " \
+        "label=#{label.inspect} value=#{value.inspect} allow_blank=#{allow_blank}"
+    end
+  end
+
+  def log_wait_for_selected_initial_state(value_input_selector)
+    has_value_input_initial = scope.page.has_selector?(value_input_selector, visible: false, wait: 0)
+    current_value_initial = scope.page.first(value_input_selector, visible: false, wait: 0)&.[](:value)
+    current_option = scope.page.first(
+      "#{base_selector} [data-class='current-selected'] [data-class='current-option']",
+      minimum: 0,
+      wait: 0
+    )
+    current_label_initial =
+      if current_option
+        option_text = current_option.first("[data-testid='option-presentation-text']", minimum: 0)
+        option_text ? option_text.text : current_option.text
+      end
+
+    Rails.logger.debug do
+      "[haya_select] wait_for_selected_value_or_label initial " \
+        "selector=#{base_selector} has_value_input=#{has_value_input_initial} " \
+        "current_value=#{current_value_initial.inspect} " \
+        "current_label=#{current_label_initial.inspect}"
+    end
+  end
+
+  def selected_value_or_label_matches?(label:, value:, allow_blank:, value_input_selector:)
+    has_value_input = scope.page.has_selector?(value_input_selector, visible: false)
+    value_matches = value && scope.page.has_selector?(current_value_selector(value), visible: false)
+    blank_matches = allow_blank && scope.page.has_selector?(current_value_selector(""), visible: false)
+    return value_matches || blank_matches if has_value_input
+
+    label_matches = label && label_matches?(label)
+    label_matches || value_matches || blank_matches
   end
 
   # rubocop:enable Metrics/ClassLength, Style/Documentation


### PR DESCRIPTION
## Summary
- replace debug  calls in  with 
- use block-form logger calls to avoid eager interpolation
- keep release rake task logging unchanged

## Testing
- bundle exec rubocop lib/haya_select.rb --only Layout/LineLength,Rails/EagerEvaluationLogMessage