### PR TITLE
Fix non-raising select state logging when hidden input is absent

### DIFF
--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -655,7 +655,7 @@ private
 
   def log_wait_for_selected_initial_state(value_input_selector)
     has_value_input_initial = scope.page.has_selector?(value_input_selector, visible: false, wait: 0)
-    current_value_initial = scope.page.first(value_input_selector, visible: false, wait: 0)&.[](:value)
+    current_value_initial = scope.page.first(value_input_selector, minimum: 0, visible: false, wait: 0)&.[](:value)
     current_option = scope.page.first(
       "#{base_selector} [data-class='current-selected'] [data-class='current-option']",
       minimum: 0,

--- a/spec/haya_select_spec.rb
+++ b/spec/haya_select_spec.rb
@@ -5,6 +5,26 @@ class HayaSelectSpecScope
 end
 
 describe HayaSelect do
+  describe "#log_wait_for_selected_initial_state" do
+    it "does not raise when hidden input is missing" do
+      page = instance_double(Capybara::Session)
+      scope = instance_double(HayaSelectSpecScope, page: page)
+      value_input_selector = "[data-component='haya-select'][data-id='example'] [data-class='current-selected'] input[type='hidden']"
+
+      expect(page).to receive(:has_selector?).with(value_input_selector, visible: false, wait: 0).and_return(false)
+      expect(page).to receive(:first).with(value_input_selector, minimum: 0, visible: false, wait: 0).and_return(nil)
+      expect(page).to receive(:first).with(
+        "[data-component='haya-select'][data-id='example'] [data-class='current-selected'] [data-class='current-option']",
+        minimum: 0,
+        wait: 0
+      ).and_return(nil)
+
+      expect do
+        HayaSelect.new(id: "example", scope: scope).__send__(:log_wait_for_selected_initial_state, value_input_selector)
+      end.not_to raise_error
+    end
+  end
+
   describe "#value_no_wait" do
     it "returns nil when the hidden input is missing" do
       page = instance_double(Capybara::Session)


### PR DESCRIPTION
## Problem
Recent changes added debug logging in `log_wait_for_selected_initial_state`, but it used `page.first(..., wait: 0)` without `minimum: 0`.
When the hidden input is temporarily absent, Capybara raises `ExpectationNotMet`, so logging code can fail otherwise-valid select flows.

## Fix
- Add `minimum: 0` to the hidden-input lookup in `log_wait_for_selected_initial_state`.
- Add a spec that verifies this method does not raise when the hidden input is missing.

## Testing
- `bundle exec rubocop lib/haya_select.rb spec/haya_select_spec.rb`
- `bundle exec rspec spec/haya_select_spec.rb`