### PR TITLE
Reduce haya-select helper wait overhead

### DIFF
--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -96,7 +96,7 @@ class HayaSelect
 
     begin
       debug_log do
-        "[haya_select] select start selector=#{base_selector} " \
+        "select start selector=#{base_selector} " \
           "label=#{label.inspect} value=#{value.inspect} " \
           "allow_if_selected=#{allow_if_selected} attempts=#{attempts}"
       end
@@ -106,7 +106,7 @@ class HayaSelect
       wait_for_selected_after_select(label, value, selected_value, allow_blank)
       self
     rescue WaitUtil::TimeoutError, Selenium::WebDriver::Error::StaleElementReferenceError
-      debug_log { "[haya_select] select retry selector=#{base_selector} attempts=#{attempts}" }
+      debug_log { "select retry selector=#{base_selector} attempts=#{attempts}" }
       attempts += 1
       retry if attempts < 3
       raise
@@ -195,13 +195,13 @@ class HayaSelect
 
     selector = select_option_selector(label: label, value: value)
     debug_log do
-      "[haya_select] select_option_value selector=#{base_selector} " \
+      "select_option_value selector=#{base_selector} " \
         "option_selector=#{selector} label=#{label.inspect} value=#{value.inspect}"
     end
     wait_for_option(selector)
     option = find_option_element(selector, label)
     debug_log do
-      "[haya_select] option_element selector=#{base_selector} " \
+      "option_element selector=#{base_selector} " \
         "data-value=#{option['data-value'].inspect} " \
         "data-disabled=#{option['data-disabled'].inspect} " \
         "data-selected=#{option['data-selected'].inspect}"
@@ -609,7 +609,7 @@ private
 
   def perform_option_selection(option, label, option_value, wait_for_selection: true)
     debug_log do
-      "[haya_select] perform_option_selection selector=#{base_selector} " \
+      "perform_option_selection selector=#{base_selector} " \
         "label=#{label.inspect} option_value=#{option_value.inspect} " \
         "data-selected=#{option['data-selected'].inspect} wait_for_selection=#{wait_for_selection}"
     end
@@ -623,15 +623,15 @@ private
 
   def select_value_and_close(label:, value:)
     previous_value = value
-    debug_log { "[haya_select] open selector=#{base_selector}" }
+    debug_log { "open selector=#{base_selector}" }
     open
     selected_value = select_option_value(label:, value:, wait_for_selection: false)
     debug_log do
-      "[haya_select] select_option_value selector=#{base_selector} selected_value=#{selected_value.inspect}"
+      "select_option_value selector=#{base_selector} selected_value=#{selected_value.inspect}"
     end
     selected_value = "" if selected_value.nil? && value.nil?
     allow_blank = previous_value == selected_value
-    debug_log { "[haya_select] close_if_open selector=#{base_selector}" }
+    debug_log { "close_if_open selector=#{base_selector}" }
     close_if_open
     [selected_value, allow_blank]
   end
@@ -639,7 +639,7 @@ private
   def wait_for_selected_after_select(label, value, selected_value, allow_blank)
     expected_value = value || selected_value
     debug_log do
-      "[haya_select] wait_for_selected_value_or_label selector=#{base_selector} " \
+      "wait_for_selected_value_or_label selector=#{base_selector} " \
         "label=#{label.inspect} value=#{expected_value.inspect} allow_blank=#{allow_blank}"
     end
     wait_for_selected_value_or_label(label, expected_value, allow_blank:)
@@ -648,7 +648,7 @@ private
   def debug_log(&)
     return unless debug
 
-    Rails.logger.debug(&)
+    Rails.logger.debug { "[haya_select] #{yield}" }
   end
 
   def selected_value_or_label_matches?(label:, value:, allow_blank:, value_input_selector:)

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -93,14 +93,12 @@ class HayaSelect
     attempts = 0
 
     begin
-      log_select_start(label, value, allow_if_selected, attempts)
       guard_already_selected(label, value, allow_if_selected) if attempts.zero?
 
       selected_value, allow_blank = select_value_and_close(label:, value:)
       wait_for_selected_after_select(label, value, selected_value, allow_blank)
       self
     rescue WaitUtil::TimeoutError, Selenium::WebDriver::Error::StaleElementReferenceError
-      log_select_retry(attempts)
       attempts += 1
       retry if attempts < 3
       raise
@@ -184,26 +182,17 @@ class HayaSelect
     retry
   end
 
-  def select_option_value(label: nil, value: nil)
+  def select_option_value(label: nil, value: nil, wait_for_selection: true)
     raise "No 'label' or 'value' given" if label.nil? && value.nil?
 
     selector = select_option_selector(label: label, value: value)
-    Rails.logger.debug do
-      "[haya_select] select_option_value selector=#{base_selector} option_selector=#{selector} label=#{label.inspect} value=#{value.inspect}"
-    end
     wait_for_option(selector)
     option = find_option_element(selector, label)
-    Rails.logger.debug do
-      "[haya_select] option_element selector=#{base_selector} " \
-        "data-value=#{option['data-value'].inspect} " \
-        "data-disabled=#{option['data-disabled'].inspect} " \
-        "data-selected=#{option['data-selected'].inspect}"
-    end
 
     raise "The '#{label}'-option is disabled" if option['data-disabled'] == 'true'
 
     option_value = option['data-value']
-    perform_option_selection(option, label, option_value)
+    perform_option_selection(option, label, option_value, wait_for_selection:)
 
     option_value
   rescue Selenium::WebDriver::Error::StaleElementReferenceError
@@ -354,9 +343,7 @@ private
   end
 
   def wait_for_selected_value_or_label(label, value, allow_blank: false)
-    log_wait_for_selected_start(label, value, allow_blank)
     value_input_selector = "#{base_selector} [data-class='current-selected'] input[type='hidden']"
-    log_wait_for_selected_initial_state(value_input_selector)
 
     if scope.page.has_selector?(value_input_selector, visible: false, wait: 0)
       return wait_for_selector(current_value_selector(value), visible: false) if value
@@ -602,85 +589,28 @@ private
     element.click
   end
 
-  def perform_option_selection(option, label, option_value)
-    Rails.logger.debug do
-      "[haya_select] perform_option_selection selector=#{base_selector} " \
-        "label=#{label.inspect} option_value=#{option_value.inspect} " \
-        "data-selected=#{option['data-selected'].inspect}"
-    end
+  def perform_option_selection(option, label, option_value, wait_for_selection: true)
     click_option_element(option)
-    wait_for_selected_value_or_label(label, option_value)
+    wait_for_selected_value_or_label(label, option_value) if wait_for_selection
   end
 
   def select_option_container_selector
     "#{options_selector} [data-class='select-option']"
   end
 
-  def log_select_start(label, value, allow_if_selected, attempts)
-    Rails.logger.debug do
-      "[haya_select] select start selector=#{base_selector} " \
-        "label=#{label.inspect} value=#{value.inspect} " \
-        "allow_if_selected=#{allow_if_selected} attempts=#{attempts}"
-    end
-  end
-
   def select_value_and_close(label:, value:)
     previous_value = value
-    Rails.logger.debug { "[haya_select] open selector=#{base_selector}" }
     open
-    Rails.logger.debug { "[haya_select] select_option_value selector=#{base_selector}" }
-    selected_value = select_option_value(label:, value:)
-    Rails.logger.debug do
-      "[haya_select] select_option_value selector=#{base_selector} selected_value=#{selected_value.inspect}"
-    end
+    selected_value = select_option_value(label:, value:, wait_for_selection: false)
     selected_value = "" if selected_value.nil? && value.nil?
     allow_blank = previous_value == selected_value
-    Rails.logger.debug { "[haya_select] close_if_open selector=#{base_selector}" }
     close_if_open
     [selected_value, allow_blank]
   end
 
   def wait_for_selected_after_select(label, value, selected_value, allow_blank)
     expected_value = value || selected_value
-    Rails.logger.debug do
-      "[haya_select] wait_for_selected_value_or_label " \
-        "selector=#{base_selector} label=#{label.inspect} " \
-        "value=#{expected_value.inspect} allow_blank=#{allow_blank}"
-    end
     wait_for_selected_value_or_label(label, expected_value, allow_blank:)
-  end
-
-  def log_select_retry(attempts)
-    Rails.logger.debug { "[haya_select] select retry selector=#{base_selector} attempts=#{attempts}" }
-  end
-
-  def log_wait_for_selected_start(label, value, allow_blank)
-    Rails.logger.debug do
-      "[haya_select] wait_for_selected_value_or_label start selector=#{base_selector} " \
-        "label=#{label.inspect} value=#{value.inspect} allow_blank=#{allow_blank}"
-    end
-  end
-
-  def log_wait_for_selected_initial_state(value_input_selector)
-    has_value_input_initial = scope.page.has_selector?(value_input_selector, visible: false, wait: 0)
-    current_value_initial = scope.page.first(value_input_selector, minimum: 0, visible: false, wait: 0)&.[](:value)
-    current_option = scope.page.first(
-      "#{base_selector} [data-class='current-selected'] [data-class='current-option']",
-      minimum: 0,
-      wait: 0
-    )
-    current_label_initial =
-      if current_option
-        option_text = current_option.first("[data-testid='option-presentation-text']", minimum: 0)
-        option_text ? option_text.text : current_option.text
-      end
-
-    Rails.logger.debug do
-      "[haya_select] wait_for_selected_value_or_label initial " \
-        "selector=#{base_selector} has_value_input=#{has_value_input_initial} " \
-        "current_value=#{current_value_initial.inspect} " \
-        "current_label=#{current_label_initial.inspect}"
-    end
   end
 
   def selected_value_or_label_matches?(label:, value:, allow_blank:, value_input_selector:)

--- a/lib/haya_select_helpers.rb
+++ b/lib/haya_select_helpers.rb
@@ -3,7 +3,7 @@ require "haya_select_helpers/version"
 require "haya_select_helpers/engine"
 
 module HayaSelectHelpers
-  def haya_select(id)
-    HayaSelect.new(id: id, scope: self)
+  def haya_select(id, debug: false)
+    HayaSelect.new(id: id, scope: self, debug:)
   end
 end

--- a/spec/haya_select_spec.rb
+++ b/spec/haya_select_spec.rb
@@ -133,4 +133,22 @@ describe HayaSelect do
       end.not_to raise_error
     end
   end
+
+  describe "#debug_log" do
+    it "does not log when debug is false" do
+      scope = instance_double(HayaSelectSpecScope)
+      select = HayaSelect.new(id: "example", scope: scope, debug: false)
+
+      expect(Rails.logger).not_to receive(:debug)
+      select.__send__(:debug_log) { "hello" }
+    end
+
+    it "logs when debug is true" do
+      scope = instance_double(HayaSelectSpecScope)
+      select = HayaSelect.new(id: "example", scope: scope, debug: true)
+
+      expect(Rails.logger).to receive(:debug)
+      select.__send__(:debug_log) { "hello" }
+    end
+  end
 end


### PR DESCRIPTION
## Problem
System builds still spend too much time in select helpers. Two issues were contributing:
- select flow waited for selection state twice (before close and again after close)
- verbose per-select debug logging added unnecessary IO overhead during large system runs

## Fix
- keep a single authoritative wait in `select` after closing the dropdown
- skip the pre-close wait in `select_value_and_close` by passing `wait_for_selection: false`
- remove noisy debug logging helpers/calls from hot select paths

## Testing
- `bundle exec rubocop lib/haya_select.rb spec/haya_select_spec.rb`
- `bundle exec rspec spec/haya_select_spec.rb`}