### PR TITLE
Default haya-select debug flag from env

### DIFF
--- a/lib/haya_select_helpers.rb
+++ b/lib/haya_select_helpers.rb
@@ -3,7 +3,7 @@ require "haya_select_helpers/version"
 require "haya_select_helpers/engine"
 
 module HayaSelectHelpers
-  def haya_select(id, debug: false)
+  def haya_select(id, debug: ENV["HAYA_SELECT_DEBUG"] == "1")
     HayaSelect.new(id: id, scope: self, debug:)
   end
 end


### PR DESCRIPTION
## Problem
To debug freezing/select slowness in consuming apps, we need to enable helper debug logs without adding project-side monkey patches.

## Fix
- update `haya_select` helper default debug argument to read from `ENV["HAYA_SELECT_DEBUG"] == "1"`
- this keeps existing explicit `debug:` overrides working

## Testing
- `bundle exec rubocop lib/haya_select_helpers.rb`
- `bundle exec rspec spec/haya_select_spec.rb`}