### PR TITLE
Fix flaky open flow in HayaSelect helper

### DIFF
--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -45,7 +45,7 @@ class HayaSelect
     attempts = 0
 
     begin
-      wait_for_selector("#{base_selector}[data-opened='false']", timeout: 3)
+      wait_for_selector("#{base_selector}[data-opened='false']", wait: 3)
       click_open_target_element
       wait_for_open
       self

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -45,12 +45,13 @@ class HayaSelect
     attempts = 0
 
     begin
+      wait_for_selector("#{base_selector}[data-opened='false']")
+      wait_for_no_selector(options_selector, visible: :all)
       click_open_target_element
       wait_for_open
       self
     rescue WaitUtil::TimeoutError, Selenium::WebDriver::Error::StaleElementReferenceError
       attempts += 1
-      send_open_key
       retry if attempts < 3
       raise "Failed to open haya-select options for '#{base_selector}' (options container not found)"
     end
@@ -512,14 +513,6 @@ private
     )
     close_target ||= wait_for_and_find("body")
     scope.page.driver.browser.action.move_to(close_target.native).click.perform
-  end
-
-  def send_open_key
-    return unless scope.page.has_selector?(select_container_selector, wait: 0)
-
-    select_container = wait_for_and_find(select_container_selector)
-    select_container.send_keys(:enter)
-    select_container.send_keys(:space)
   end
 
   def current_option_label_selectors

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -316,6 +316,9 @@ private
   def label_matches_selected_value?(label)
     return false unless label
 
+    current_label = label_no_wait
+    return current_label == label if current_label
+
     current_value = value_no_wait
     return false if current_value.nil? || current_value == ""
 

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -45,7 +45,7 @@ class HayaSelect
     attempts = 0
 
     begin
-      wait_for_selector("#{base_selector}[data-opened='false']")
+      wait_for_selector("#{base_selector}[data-opened='false']", timeout: 3)
       click_open_target_element
       wait_for_open
       self
@@ -647,10 +647,10 @@ private
     has_value_input = scope.page.has_selector?(value_input_selector, visible: false, wait: 0)
     value_matches = current_value_matches?(value)
     blank_matches = blank_value_matches?(allow_blank)
-    return value_matches || blank_matches if has_value_input
-
     selected_option_matches = selected_option_matches?(value)
     label_matches = label && label_matches?(label)
+    return value_matches || label_matches || selected_option_matches || blank_matches if has_value_input
+
     label_matches || value_matches || selected_option_matches || blank_matches
   end
 

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -46,7 +46,6 @@ class HayaSelect
 
     begin
       wait_for_selector("#{base_selector}[data-opened='false']")
-      wait_for_no_selector(options_selector, visible: :all)
       click_open_target_element
       wait_for_open
       self

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -589,7 +589,10 @@ private
 
   def selected_option_value_or_raise(option:, label:, value:, allow_if_selected:)
     return unless option['data-selected'] == 'true'
-    return option["data-value"] if allow_if_selected
+
+    option_value = option["data-value"] || value
+    return unless selected?(label, option_value)
+    return option_value if allow_if_selected
 
     raise "The '#{label || value}'-option is already selected"
   end


### PR DESCRIPTION
## Problem
`HayaSelect#open` used a keyboard fallback (`enter`/`space`) after open failures. This creates inconsistent behavior and can interact badly with rerenders/focus races.

## Fix
- Removed keyboard fallback from `open`
- Before clicking, explicitly wait for closed state:
  - `data-opened='false'`
  - no visible options container

## Testing
- `bundle exec rubocop lib/haya_select.rb`