### PR TITLE
Wait for visible options state before selecting options

### DIFF
--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -345,7 +345,8 @@ private
   end
 
   def wait_for_option(selector)
-    wait_for_selector(selector, visible: :all)
+    wait_for_options_visible
+    wait_for_selector(selector)
   end
 
   def open_and_find_option_for(label:, value:)
@@ -559,6 +560,22 @@ private
 
   def option_label_selector
     "#{options_selector} [data-testid='option-presentation-text']"
+  end
+
+  def options_visibility_selector
+    "#{options_selector}[data-options-visibility]"
+  end
+
+  def options_visible_selector
+    "#{options_selector}[data-options-visibility='visible']"
+  end
+
+  def wait_for_options_visible
+    if scope.page.has_selector?(options_visibility_selector, visible: :all, wait: 0)
+      wait_for_selector(options_visible_selector, visible: :all)
+    else
+      wait_for_selector(options_selector, visible: :all)
+    end
   end
 
   def option_present?(selector, label)

--- a/spec/haya_select_spec.rb
+++ b/spec/haya_select_spec.rb
@@ -101,6 +101,61 @@ describe HayaSelect do
     end
   end
 
+  describe "#wait_for_option" do
+    it "waits for visible options before looking up option selector" do
+      scope = instance_double(HayaSelectSpecScope)
+      select = HayaSelect.new(id: "example", scope: scope)
+
+      expect(select).to receive(:wait_for_options_visible)
+      expect(scope).to receive(:wait_for_selector).with(
+        "[data-class='options-container'][data-id='example'] [data-class='select-option'][data-value='norway']"
+      )
+
+      select.__send__(
+        :wait_for_option,
+        "[data-class='options-container'][data-id='example'] [data-class='select-option'][data-value='norway']"
+      )
+    end
+  end
+
+  describe "#wait_for_options_visible" do
+    it "waits for explicit visible state when options visibility data is present" do
+      page = instance_double(Capybara::Session)
+      scope = instance_double(HayaSelectSpecScope, page: page)
+      select = HayaSelect.new(id: "example", scope: scope)
+
+      expect(page).to receive(:has_selector?).with(
+        "[data-class='options-container'][data-id='example'][data-options-visibility]",
+        visible: :all,
+        wait: 0
+      ).and_return(true)
+      expect(scope).to receive(:wait_for_selector).with(
+        "[data-class='options-container'][data-id='example'][data-options-visibility='visible']",
+        visible: :all
+      )
+
+      select.__send__(:wait_for_options_visible)
+    end
+
+    it "falls back to waiting for options container when visibility data is absent" do
+      page = instance_double(Capybara::Session)
+      scope = instance_double(HayaSelectSpecScope, page: page)
+      select = HayaSelect.new(id: "example", scope: scope)
+
+      expect(page).to receive(:has_selector?).with(
+        "[data-class='options-container'][data-id='example'][data-options-visibility]",
+        visible: :all,
+        wait: 0
+      ).and_return(false)
+      expect(scope).to receive(:wait_for_selector).with(
+        "[data-class='options-container'][data-id='example']",
+        visible: :all
+      )
+
+      select.__send__(:wait_for_options_visible)
+    end
+  end
+
   describe "#value_no_wait" do
     it "returns nil when the hidden input is missing" do
       page = instance_double(Capybara::Session)


### PR DESCRIPTION
## Problem
`haya_select` helper could proceed after detecting option nodes with `visible: :all`, then fail when trying to find/click visible options while the dropdown was still hidden in slower CI runs.

## Fix
- Added `wait_for_options_visible` and used it from `wait_for_option`.
- When `data-options-visibility` exists, waits for `data-options-visibility='visible'` before selecting.
- Keeps backward-compatible fallback for older components without the attribute.
- Added focused specs for visible-state synchronization behavior.

## Testing
- `bundle exec rubocop lib/haya_select.rb spec/haya_select_spec.rb`
- `bundle exec rspec spec/haya_select_spec.rb`
