### PR TITLE
Improve haya-select open/select resilience

### DIFF
--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -337,7 +337,7 @@ private
 
   def select_option_selector(label:, value:)
     if value
-      "#{select_option_container_selector}[data-value='#{value}']"
+      select_option_container_selector(option_attributes: "[data-value='#{value}']")
     else
       selector = option_presentation_selector
       selector << "[data-text='#{label}']" unless label.nil?
@@ -494,7 +494,7 @@ private
   end
 
   def wait_for_open
-    wait_for_selector("#{base_selector}[data-opened='true']", visible: :all)
+    wait_for_selector(opened_base_selector, visible: :all)
   end
 
   def click_element_safely(element)
@@ -567,7 +567,7 @@ private
   end
 
   def no_options_selector
-    "#{options_root_selector} [data-class='no-options-container']"
+    options_root_descendant_selector("[data-class='no-options-container']")
   end
 
   def select_container_selector
@@ -575,15 +575,15 @@ private
   end
 
   def option_label_selector
-    "#{options_root_selector} [data-testid='option-presentation-text']"
+    options_root_descendant_selector("[data-testid='option-presentation-text']")
   end
 
   def options_visibility_selector
-    "#{options_root_selector}[data-options-visibility]"
+    options_root_attribute_selector("[data-options-visibility]")
   end
 
   def options_visible_selector
-    "#{options_root_selector}[data-options-visibility='visible']"
+    options_root_attribute_selector("[data-options-visibility='visible']")
   end
 
   def wait_for_options_visible
@@ -592,7 +592,7 @@ private
     elsif scope.page.has_selector?(options_root_selector, visible: :all, wait: 0)
       wait_for_selector(options_root_selector, visible: :all)
     else
-      wait_for_selector("#{base_selector}[data-opened='true']", visible: :all)
+      wait_for_selector(opened_base_selector, visible: :all)
     end
   end
 
@@ -666,24 +666,32 @@ private
     wait_for_selected_value_or_label(label, option_value) if wait_for_selection
   end
 
-  def select_option_container_selector
-    "#{options_root_selector} [data-class='select-option']"
+  def select_option_container_selector(option_attributes: "")
+    options_root_descendant_selector("[data-class='select-option']#{option_attributes}")
   end
 
   def option_presentation_selector
-    "#{options_root_selector} [data-testid='option-presentation']"
+    options_root_descendant_selector("[data-testid='option-presentation']")
   end
 
   def options_root_selector
-    if scope.page.has_selector?(options_selector, visible: :all, wait: 0)
-      options_selector
-    else
-      "#{base_selector}[data-opened='true']"
-    end
+    "#{options_selector}, #{opened_base_selector}"
+  end
+
+  def options_root_attribute_selector(attribute_selector)
+    "#{options_selector}#{attribute_selector}, #{opened_base_selector}#{attribute_selector}"
+  end
+
+  def options_root_descendant_selector(descendant_selector)
+    "#{options_selector} #{descendant_selector}, #{opened_base_selector} #{descendant_selector}"
+  end
+
+  def opened_base_selector
+    "#{base_selector}[data-opened='true']"
   end
 
   def select_open?
-    scope.page.has_selector?("#{base_selector}[data-opened='true']", visible: :all, wait: 0) ||
+    scope.page.has_selector?(opened_base_selector, visible: :all, wait: 0) ||
       scope.page.has_selector?(options_selector, visible: :all, wait: 0)
   end
 
@@ -736,7 +744,7 @@ private
     return false unless value
 
     scope.page.has_selector?(
-      "#{select_option_container_selector}[data-value='#{value}'][data-selected='true']",
+      select_option_container_selector(option_attributes: "[data-value='#{value}'][data-selected='true']"),
       visible: :all,
       wait: 0
     )

--- a/lib/haya_select.rb
+++ b/lib/haya_select.rb
@@ -36,7 +36,7 @@ class HayaSelect
   end
 
   def open(allow_if_open: false)
-    if scope.page.has_selector?(options_selector, visible: :all, wait: 0)
+    if select_open?
       return self if allow_if_open
 
       raise "Expected haya-select '#{base_selector}' to be closed, but it was already open"
@@ -47,12 +47,13 @@ class HayaSelect
     begin
       wait_for_selector("#{base_selector}[data-opened='false']", wait: 3)
       click_open_target_element
+      open_with_keyboard unless scope.page.has_selector?("#{base_selector}[data-opened='true']", wait: 0)
       wait_for_open
       self
-    rescue WaitUtil::TimeoutError, Selenium::WebDriver::Error::StaleElementReferenceError
+    rescue ApiMaker::SpecHelper::SelectorNotFoundError, WaitUtil::TimeoutError, Selenium::WebDriver::Error::StaleElementReferenceError
       attempts += 1
       retry if attempts < 3
-      raise "Failed to open haya-select options for '#{base_selector}' (options container not found)"
+      raise
     end
   end
 
@@ -106,7 +107,7 @@ class HayaSelect
       selected_value, allow_blank = select_value_and_close(label:, value:, allow_if_selected:)
       wait_for_selected_after_select(label, value, selected_value, allow_blank)
       self
-    rescue WaitUtil::TimeoutError, Selenium::WebDriver::Error::StaleElementReferenceError
+    rescue ApiMaker::SpecHelper::SelectorNotFoundError, WaitUtil::TimeoutError, Selenium::WebDriver::Error::StaleElementReferenceError
       debug_log { "select retry selector=#{base_selector} attempts=#{attempts}" }
       attempts += 1
       retry if attempts < 3
@@ -199,7 +200,7 @@ class HayaSelect
       "select_option_value selector=#{base_selector} " \
         "option_selector=#{selector} label=#{label.inspect} value=#{value.inspect}"
     end
-    wait_for_option(selector)
+    wait_for_option(selector, label:)
     option = find_option_element(selector, label)
     debug_log do
       "option_element selector=#{base_selector} " \
@@ -338,13 +339,20 @@ private
     if value
       "#{select_option_container_selector}[data-value='#{value}']"
     else
-      selector = "#{options_selector} [data-testid='option-presentation']"
+      selector = option_presentation_selector
       selector << "[data-text='#{label}']" unless label.nil?
       selector
     end
   end
 
-  def wait_for_option(selector)
+  def wait_for_option(selector, label: nil)
+    wait_for_options_visible
+    wait_for_selector(selector)
+  rescue ApiMaker::SpecHelper::SelectorNotFoundError, WaitUtil::TimeoutError
+    raise unless label
+    raise unless scope.page.has_selector?(search_input_selector, wait: 0)
+
+    search_for_option(label)
     wait_for_options_visible
     wait_for_selector(selector)
   end
@@ -352,7 +360,7 @@ private
   def open_and_find_option_for(label:, value:)
     open
     selector = select_option_selector(label: label, value: value)
-    wait_for_option(selector)
+    wait_for_option(selector, label:)
     option = find_option_element(selector, label)
     option_value = option['data-value']
     [option, option_value]
@@ -426,18 +434,18 @@ private
   end
 
   def close_if_open
-    return if scope.page.has_no_selector?(options_selector, visible: :all, wait: 0)
+    return unless select_open?
 
     close_attempts = 0
 
-    while scope.page.has_selector?(options_selector, visible: :all, wait: 0) && close_attempts < 3
+    while select_open? && close_attempts < 3
       close_attempt
       break if wait_for_close?
 
       close_attempts += 1
     end
 
-    return if scope.page.has_no_selector?(options_selector, visible: :all, wait: 0)
+    return unless select_open?
 
     body = wait_for_and_find("body")
     body.send_keys(:escape)
@@ -448,7 +456,7 @@ private
   end
 
   def wait_for_close?
-    scope.page.has_no_selector?(options_selector, visible: :all, wait: 1)
+    scope.page.has_selector?("#{base_selector}[data-opened='false']", visible: :all, wait: 1)
   end
 
   def search_input_selector
@@ -473,12 +481,20 @@ private
     click_element_safely(element)
   end
 
+  def open_with_keyboard
+    target = scope.page.first(select_container_selector, minimum: 0)
+    target ||= scope.page.first(current_selected_selector, minimum: 0)
+    return unless target
+
+    target.send_keys(:enter)
+  end
+
   def current_selected_selector
     "#{base_selector} [data-class='current-selected']"
   end
 
   def wait_for_open
-    wait_for_selector(options_selector, visible: :all)
+    wait_for_selector("#{base_selector}[data-opened='true']", visible: :all)
   end
 
   def click_element_safely(element)
@@ -551,7 +567,7 @@ private
   end
 
   def no_options_selector
-    "#{options_selector} [data-class='no-options-container']"
+    "#{options_root_selector} [data-class='no-options-container']"
   end
 
   def select_container_selector
@@ -559,22 +575,24 @@ private
   end
 
   def option_label_selector
-    "#{options_selector} [data-testid='option-presentation-text']"
+    "#{options_root_selector} [data-testid='option-presentation-text']"
   end
 
   def options_visibility_selector
-    "#{options_selector}[data-options-visibility]"
+    "#{options_root_selector}[data-options-visibility]"
   end
 
   def options_visible_selector
-    "#{options_selector}[data-options-visibility='visible']"
+    "#{options_root_selector}[data-options-visibility='visible']"
   end
 
   def wait_for_options_visible
     if scope.page.has_selector?(options_visibility_selector, visible: :all, wait: 0)
       wait_for_selector(options_visible_selector, visible: :all)
+    elsif scope.page.has_selector?(options_root_selector, visible: :all, wait: 0)
+      wait_for_selector(options_root_selector, visible: :all)
     else
-      wait_for_selector(options_selector, visible: :all)
+      wait_for_selector("#{base_selector}[data-opened='true']", visible: :all)
     end
   end
 
@@ -649,13 +667,30 @@ private
   end
 
   def select_option_container_selector
-    "#{options_selector} [data-class='select-option']"
+    "#{options_root_selector} [data-class='select-option']"
+  end
+
+  def option_presentation_selector
+    "#{options_root_selector} [data-testid='option-presentation']"
+  end
+
+  def options_root_selector
+    if scope.page.has_selector?(options_selector, visible: :all, wait: 0)
+      options_selector
+    else
+      "#{base_selector}[data-opened='true']"
+    end
+  end
+
+  def select_open?
+    scope.page.has_selector?("#{base_selector}[data-opened='true']", visible: :all, wait: 0) ||
+      scope.page.has_selector?(options_selector, visible: :all, wait: 0)
   end
 
   def select_value_and_close(label:, value:, allow_if_selected: false)
     previous_value = value
     debug_log { "open selector=#{base_selector}" }
-    open
+    self.open(allow_if_open: true)
     selected_value = select_option_value(label:, value:, wait_for_selection: false, **select_option_value_allow_args(allow_if_selected))
     debug_log do
       "select_option_value selector=#{base_selector} selected_value=#{selected_value.inspect}"

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,0 +1,18 @@
+example_id                                         | status | run_time        |
+-------------------------------------------------- | ------ | --------------- |
+./spec/haya_select_spec.rb[1:1:1]                  | passed | 0.00085 seconds |
+./spec/haya_select_spec.rb[1:2:1]                  | passed | 0.00543 seconds |
+./spec/haya_select_spec.rb[1:2:2]                  | failed | 0.06139 seconds |
+./spec/haya_select_spec.rb[1:3:1]                  | passed | 0.00038 seconds |
+./spec/haya_select_spec.rb[1:4:1]                  | passed | 0.0008 seconds  |
+./spec/haya_select_spec.rb[1:5:1]                  | passed | 0.00441 seconds |
+./spec/haya_select_spec.rb[1:6:1]                  | failed | 0.00098 seconds |
+./spec/haya_select_spec.rb[1:6:2]                  | failed | 0.0013 seconds  |
+./spec/haya_select_spec.rb[1:7:1]                  | passed | 0.00031 seconds |
+./spec/haya_select_spec.rb[1:8:1]                  | passed | 0.00115 seconds |
+./spec/haya_select_spec.rb[1:9:1]                  | passed | 0.00025 seconds |
+./spec/haya_select_spec.rb[1:9:2]                  | passed | 0.00038 seconds |
+./spec/system/dummy_react_haya_select_spec.rb[1:1] | failed | 0.85982 seconds |
+./spec/system/dummy_react_haya_select_spec.rb[1:2] | failed | 1.32 seconds    |
+./spec/system/dummy_react_haya_select_spec.rb[1:3] | failed | 0.85082 seconds |
+./spec/system/dummy_react_haya_select_spec.rb[1:4] | failed | 0.85426 seconds |

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,17 +1,17 @@
 example_id                                         | status | run_time        |
 -------------------------------------------------- | ------ | --------------- |
-./spec/haya_select_spec.rb[1:1:1]                  | passed | 0.00085 seconds |
-./spec/haya_select_spec.rb[1:2:1]                  | passed | 0.00543 seconds |
-./spec/haya_select_spec.rb[1:2:2]                  | failed | 0.06139 seconds |
-./spec/haya_select_spec.rb[1:3:1]                  | passed | 0.00038 seconds |
-./spec/haya_select_spec.rb[1:4:1]                  | passed | 0.0008 seconds  |
-./spec/haya_select_spec.rb[1:5:1]                  | passed | 0.00441 seconds |
-./spec/haya_select_spec.rb[1:6:1]                  | failed | 0.00098 seconds |
-./spec/haya_select_spec.rb[1:6:2]                  | failed | 0.0013 seconds  |
-./spec/haya_select_spec.rb[1:7:1]                  | passed | 0.00031 seconds |
-./spec/haya_select_spec.rb[1:8:1]                  | passed | 0.00115 seconds |
-./spec/haya_select_spec.rb[1:9:1]                  | passed | 0.00025 seconds |
-./spec/haya_select_spec.rb[1:9:2]                  | passed | 0.00038 seconds |
+./spec/haya_select_spec.rb[1:1:1]                  | passed | 0.00075 seconds |
+./spec/haya_select_spec.rb[1:2:1]                  | passed | 0.00033 seconds |
+./spec/haya_select_spec.rb[1:2:2]                  | passed | 0.00057 seconds |
+./spec/haya_select_spec.rb[1:3:1]                  | passed | 0.00034 seconds |
+./spec/haya_select_spec.rb[1:4:1]                  | passed | 0.00071 seconds |
+./spec/haya_select_spec.rb[1:5:1]                  | passed | 0.00042 seconds |
+./spec/haya_select_spec.rb[1:6:1]                  | passed | 0.0114 seconds  |
+./spec/haya_select_spec.rb[1:6:2]                  | passed | 0.00072 seconds |
+./spec/haya_select_spec.rb[1:7:1]                  | passed | 0.00047 seconds |
+./spec/haya_select_spec.rb[1:8:1]                  | passed | 0.00098 seconds |
+./spec/haya_select_spec.rb[1:9:1]                  | passed | 0.00043 seconds |
+./spec/haya_select_spec.rb[1:9:2]                  | passed | 0.00025 seconds |
 ./spec/system/dummy_react_haya_select_spec.rb[1:1] | failed | 0.85982 seconds |
 ./spec/system/dummy_react_haya_select_spec.rb[1:2] | failed | 1.32 seconds    |
 ./spec/system/dummy_react_haya_select_spec.rb[1:3] | failed | 0.85082 seconds |

--- a/spec/haya_select_spec.rb
+++ b/spec/haya_select_spec.rb
@@ -50,7 +50,10 @@ describe HayaSelect do
       select = HayaSelect.new(id: "example", scope: scope)
       value_input_selector = "[data-component='haya-select'][data-id='example'] [data-class='current-selected'] input[type='hidden']"
       current_value_selector = "[data-component='haya-select'][data-id='example'] [data-class='current-selected'] input[type='hidden'][value='norway']"
-      selected_option_selector = "[data-class='options-container'][data-id='example'] [data-class='select-option'][data-value='norway'][data-selected='true']"
+      selected_option_selector = "[data-class='options-container'][data-id='example'] " \
+        "[data-class='select-option'][data-value='norway'][data-selected='true'], " \
+        "[data-component='haya-select'][data-id='example'][data-opened='true'] " \
+        "[data-class='select-option'][data-value='norway'][data-selected='true']"
 
       expect(page).to receive(:has_selector?).with(value_input_selector, visible: false, wait: 0).and_return(false)
       expect(page).to receive(:has_selector?).with(current_value_selector, visible: false, wait: 0).and_return(false)
@@ -123,14 +126,18 @@ describe HayaSelect do
       page = instance_double(Capybara::Session)
       scope = instance_double(HayaSelectSpecScope, page: page)
       select = HayaSelect.new(id: "example", scope: scope)
+      options_visibility_selector = "[data-class='options-container'][data-id='example'][data-options-visibility], " \
+        "[data-component='haya-select'][data-id='example'][data-opened='true'][data-options-visibility]"
+      options_visible_selector = "[data-class='options-container'][data-id='example'][data-options-visibility='visible'], " \
+        "[data-component='haya-select'][data-id='example'][data-opened='true'][data-options-visibility='visible']"
 
       expect(page).to receive(:has_selector?).with(
-        "[data-class='options-container'][data-id='example'][data-options-visibility]",
+        options_visibility_selector,
         visible: :all,
         wait: 0
       ).and_return(true)
       expect(scope).to receive(:wait_for_selector).with(
-        "[data-class='options-container'][data-id='example'][data-options-visibility='visible']",
+        options_visible_selector,
         visible: :all
       )
 
@@ -141,14 +148,23 @@ describe HayaSelect do
       page = instance_double(Capybara::Session)
       scope = instance_double(HayaSelectSpecScope, page: page)
       select = HayaSelect.new(id: "example", scope: scope)
+      options_visibility_selector = "[data-class='options-container'][data-id='example'][data-options-visibility], " \
+        "[data-component='haya-select'][data-id='example'][data-opened='true'][data-options-visibility]"
+      options_root_selector = "[data-class='options-container'][data-id='example'], " \
+        "[data-component='haya-select'][data-id='example'][data-opened='true']"
 
       expect(page).to receive(:has_selector?).with(
-        "[data-class='options-container'][data-id='example'][data-options-visibility]",
+        options_visibility_selector,
         visible: :all,
         wait: 0
       ).and_return(false)
+      expect(page).to receive(:has_selector?).with(
+        options_root_selector,
+        visible: :all,
+        wait: 0
+      ).and_return(true)
       expect(scope).to receive(:wait_for_selector).with(
-        "[data-class='options-container'][data-id='example']",
+        options_root_selector,
         visible: :all
       )
 


### PR DESCRIPTION
## Summary
- improve `HayaSelect#open`/`#select` retry behavior by handling selector-not-found paths and reducing stale-selector assumptions
- add fallback open behavior via keyboard when click-based opening does not transition to opened state
- make option lookup/search handling more robust for dynamic option containers and opened-state selectors
- align close/open waits to explicit `data-opened` state checks and centralize open-state detection
- include current local example run output in `spec/examples.txt`

## Validation
- `bundle exec rubocop lib/haya_select.rb` ✅
- `bundle exec rspec spec/haya_select_spec.rb spec/system/dummy_react_haya_select_spec.rb` ❌
  - system specs failed locally due Chrome/ChromeDriver mismatch (`Chrome 139` vs `ChromeDriver 145`)
  - unit spec doubles in `spec/haya_select_spec.rb` failed due updated selector-check behavior in `options_root_selector`
